### PR TITLE
벽감지와 장애물 로직 추가 및 수정

### DIFF
--- a/robot_drive_pkg/CMakeLists.txt
+++ b/robot_drive_pkg/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.8)
+project(robot_drive_pkg)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(geometry_megs REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+  endif()
+  add_executable(scan_node src/scan.cpp)
+  ament_target_dependencies(scan_node rclcpp std_msgs geometry_msgs sensor_msgs)
+  add_executable(drive_node src/drive.cpp)
+  ament_target_dependencies(drive_node rclcpp std_msgs geometry_msgs )
+  
+  install(TARGETS 
+    drive_node
+    scan_node
+    DESTINATION lib/${PROJECT_NAME}
+      )
+  
+  ament_package()

--- a/robot_drive_pkg/package.xml
+++ b/robot_drive_pkg/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>robot_drive_pkg</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="godma531@naver.com">hae</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>geometry_megs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/robot_drive_pkg/src/drive.cpp
+++ b/robot_drive_pkg/src/drive.cpp
@@ -1,0 +1,260 @@
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/twist.hpp" // 퍼블리셔(보내는 쪽)
+#include "geometry_msgs/msg/vector3.hpp" // 서브스크라이버(받는 쪽)
+#include <iostream>
+#include <csignal>
+#include <chrono>
+#include <thread>
+#include <map>
+
+using namespace std;
+
+// TurtlebotController 클래스 정의
+class TurtlebotController : public rclcpp::Node {
+private:
+    rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_publisher_;
+    rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr sensor_right_subscriber_;
+    rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr sensor_left_subscriber_;
+    rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr sensor_subscriber_;
+    geometry_msgs::msg::Vector3 sensor_right_data_;
+    geometry_msgs::msg::Vector3 sensor_left_data_;
+    geometry_msgs::msg::Vector3 sensor_data_;
+    bool obstacle_detected_;
+    double previous_left_value_;
+    double previous_right_value_;
+
+    
+    // 각도별 센서값 임계값
+    std::map<int, double> sensor_thresholds_;
+    
+
+public:
+    // 생성자: 노드 초기화 및 퍼블리셔, 서브스크립션 생성
+    TurtlebotController() : Node("robot_cleaner"), obstacle_detected_(false), previous_left_value_(0.0), previous_right_value_(0.0) {
+        // 기본 임계값 설정 (각도별로 필요에 따라 변경 가능)
+        sensor_thresholds_[0] = 25.0;
+        sensor_thresholds_[30] = 30.0;
+        sensor_thresholds_[60] = 50.0;
+        sensor_thresholds_[300] = 50.0;
+        sensor_thresholds_[330] = 30.0;
+
+        cmd_publisher_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 10);
+        sensor_subscriber_ = this->create_subscription<geometry_msgs::msg::Vector3>("aeeun", 10,
+            std::bind(&TurtlebotController::sensor_callback, this, std::placeholders::_1));
+        sensor_right_subscriber_ = this->create_subscription<geometry_msgs::msg::Vector3>("hyewon", 10,
+            std::bind(&TurtlebotController::sensor_right_callback, this, std::placeholders::_1));
+        sensor_left_subscriber_ = this->create_subscription<geometry_msgs::msg::Vector3>("dongwan", 10,
+            std::bind(&TurtlebotController::sensor_left_callback, this, std::placeholders::_1));
+        cout << "터틀봇 작동중..." << endl;
+    }
+
+    // 센서 데이터를 수신했을 때 호출되는 콜백 함수
+    void sensor_callback(const geometry_msgs::msg::Vector3::SharedPtr msg) {
+        sensor_data_ = *msg;
+        check_sensor_threshold(); 
+        check_obstacle(); 
+    }
+
+    void sensor_right_callback(const geometry_msgs::msg::Vector3::SharedPtr rmsg) {
+        sensor_right_data_ = *rmsg;
+    }
+
+    void sensor_left_callback(const geometry_msgs::msg::Vector3::SharedPtr lmsg) {
+        sensor_left_data_ = *lmsg;
+    }
+
+    // 각도별 설정값에 따라 종료 조건을 확인하는 함수
+    void check_sensor_threshold() {
+        auto message = geometry_msgs::msg::Twist();
+        bool all_below_threshold = 
+            sensor_data_.x < sensor_thresholds_[0];   // aeeun.x (0도)
+
+        bool right_sensor_below_threshold = 
+            sensor_right_data_.x < sensor_thresholds_[30] && // hyewon.x (30도)
+            sensor_right_data_.y < sensor_thresholds_[60];  // hyewon.y (60도)
+
+        bool left_sensor_below_threshold = 
+            sensor_left_data_.x < sensor_thresholds_[300] && // dongwan.x (300도)
+            sensor_left_data_.y < sensor_thresholds_[330];  // dongwan.y (330도)
+
+        if (all_below_threshold && right_sensor_below_threshold && left_sensor_below_threshold) {
+            cout << "모든 센서값이 설정값보다 작아 종료합니다." << endl;
+        // 로봇을 멈추기 위한 Twist 메시지 발행
+            message.linear.x = 0.0;
+            message.angular.z = 0.0;
+            cmd_publisher_->publish(message);
+
+            RCLCPP_INFO(this->get_logger(), "Sensor Data - 정면: %.2f, 우측: %.2f, 좌측: %.2f, 30도: %.2f, 330도: %.2f, 60도: %.2f, 300도: %.2f"
+                                , sensor_data_.x, sensor_data_.y, sensor_data_.z
+                                , sensor_right_data_.x, sensor_right_data_.y
+                                , sensor_left_data_.x, sensor_left_data_.y);
+
+            rclcpp::shutdown();
+        }
+    }   
+
+    // 장애물 감지 여부를 판단하는 함수
+    void check_obstacle() {
+        obstacle_detected_ = sensor_data_.x < 30.0; // x 값이 30.0보다 작으면 장애물 감지
+    }
+
+    // 로봇의 움직임을 제어하는 함수
+    void move_robot() {
+        while (rclcpp::ok()) {
+            auto message = geometry_msgs::msg::Twist();
+
+            if (obstacle_detected_) {
+                cout << "장애물 감지" << endl;
+                RCLCPP_INFO(this->get_logger(), "Sensor Data - 정면: %.2f, 우측: %.2f, 좌측: %.2f", sensor_data_.x, sensor_data_.y, sensor_data_.z);
+                message.linear.x = 0.0; // 전진을 멈춤
+                cmd_publisher_->publish(message); // 명령 메시지 발행
+                if (sensor_data_.y > sensor_data_.z) {
+                    left_course();
+                } else {
+                    right_course();
+                }
+                continue; // 반복문 시작
+            } else {
+                cout << "Moving forward" << endl;
+                message.linear.x = 0.15; // 전진
+                message.angular.z = 0.0; // 회전 없음
+                cmd_publisher_->publish(message); // 명령 메시지 발행
+            }
+
+            // 멈춤 조건이 만족될 때까지 대기
+            this_thread::sleep_for(0.5s); // 0.5초 대기
+        }
+    }
+
+    void right_course() {
+        auto message = geometry_msgs::msg::Twist();
+        cout << "Turning right" << endl;
+        RCLCPP_INFO(this->get_logger(), "Sensor Data - 정면: %.2f, 우측: %.2f, 좌측: %.2f", sensor_data_.x, sensor_data_.y, sensor_data_.z);
+
+        // 1. 오른쪽으로 90도 회전
+        right_turn();
+        cmd_publisher_->publish(message);
+        this_thread::sleep_for(1s); // 회전 완료 대기 (시간은 로봇의 회전 속도에 따라 조정 필요)
+
+        // 2. 직진
+        message.angular.z = 0.0; // 회전 없음
+        message.linear.x = 0.1;
+        cmd_publisher_->publish(message);
+        this_thread::sleep_for(0.5s); // 직진 시간 조정 필요
+
+        // 3. 왼쪽 값을 측정하며 이동
+        previous_left_value_ = sensor_data_.y;
+        while (rclcpp::ok()) {
+            if (obstacle_detected_) {
+                cout << "정면 장애물 감지. right_course() 종료." << endl;
+                RCLCPP_INFO(this->get_logger(), "Sensor Data - 정면: %.2f, 우측: %.2f, 좌측: %.2f", sensor_data_.x, sensor_data_.y, sensor_data_.z);
+                return; // 장애물 감지 시 함수 종료
+            }
+            if (sensor_data_.y > previous_left_value_ + 10) { // 왼쪽 값이 순간적으로 증가했을 때 멈춤
+                this_thread::sleep_for(0.5s); // 직진 시간 조정 필
+                message.linear.x = 0.0;
+                cmd_publisher_->publish(message);
+                break;
+            }
+            this_thread::sleep_for(0.1s); // 센서 체크 주기
+        }
+
+        // 4. 오른쪽으로 회전
+        left_turn();
+        cmd_publisher_->publish(message);
+        this_thread::sleep_for(1s); // 회전 완료 대기 (시간은 로봇의 회전 속도에 따라 조정 필요)
+    }
+
+    void left_course() {
+        auto message = geometry_msgs::msg::Twist();
+        cout << "Turning left" << endl;
+        RCLCPP_INFO(this->get_logger(), "Sensor Data - 정면: %.2f, 우측: %.2f, 좌측: %.2f", sensor_data_.x, sensor_data_.y, sensor_data_.z);
+
+        // 1. 왼쪽으로 90도 회전
+        left_turn();
+        cmd_publisher_->publish(message);
+        this_thread::sleep_for(1s); // 회전 완료 대기 (시간은 로봇의 회전 속도에 따라 조정 필요)
+
+        // 2. 직진
+        message.angular.z = 0.0; // 회전 없음
+        message.linear.x = 0.1;
+        cmd_publisher_->publish(message);
+        this_thread::sleep_for(0.5s); // 직진 시간 조정 필요
+
+        // 3. 오른쪽 값을 측정하며 이동
+        previous_right_value_ = sensor_data_.z;
+        while (rclcpp::ok()) {
+            if (obstacle_detected_) {
+                cout << "정면 장애물 감지. left_course() 종료." << endl;
+                RCLCPP_INFO(this->get_logger(), "Sensor Data - 정면: %.2f, 우측: %.2f, 좌측: %.2f", sensor_data_.x, sensor_data_.y, sensor_data_.z);
+                return; // 장애물 감지 시 함수 종료
+            }
+            if (sensor_data_.z > previous_right_value_ + 10) { // 오른쪽 값이 순간적으로 증가했을 때 멈춤
+                this_thread::sleep_for(0.5s); // 직진 시간 조정 필요
+                message.linear.x = 0.0;
+                cmd_publisher_->publish(message);
+                break;
+            }
+            this_thread::sleep_for(0.1s); // 센서 체크 주기
+        }
+
+        // 4. 오른쪽으로 회전
+        right_turn();
+        cmd_publisher_->publish(message);
+        this_thread::sleep_for(1s); // 회전 완료 대기 (시간은 로봇의 회전 속도에 따라 조정 필요)
+    }
+
+    void right_turn() { // 오른쪽 회전
+        RCLCPP_INFO(this->get_logger(), "Sensor Data - 정면: %.2f, 우측: %.2f, 좌측: %.2f", sensor_data_.x, sensor_data_.y, sensor_data_.z);
+        auto message = geometry_msgs::msg::Twist();
+        message.angular.z = -3.14 / 4.0; // 오른쪽으로 90도 회전
+        cmd_publisher_->publish(message);
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+        message.angular.z = 0.0;
+        cmd_publisher_->publish(message);
+    }
+
+    void left_turn() { // 왼쪽 회전
+        RCLCPP_INFO(this->get_logger(), "Sensor Data - 정면: %.2f, 우측: %.2f, 좌측: %.2f", sensor_data_.x, sensor_data_.y, sensor_data_.z);
+        auto message = geometry_msgs::msg::Twist();
+        message.angular.z = 3.14 / 4.0; // 왼쪽으로 90도 회전
+        cmd_publisher_->publish(message);
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+        message.angular.z = 0.0;
+        cmd_publisher_->publish(message);
+    }
+};
+
+// Ctrl+C 시그널을 처리하는 핸들러 함수
+void signalHandler(int /*signum*/) {
+    cout << "Ctrl+C로 종료합니다." << endl;
+
+    // 로봇을 정지시키기 위한 메시지 생성
+    auto message = geometry_msgs::msg::Twist();
+    message.linear.x = 0.0;
+    message.angular.z = 0.0;
+
+    // 로봇을 정지시키기 위해 cmd_vel 토픽에 메시지 발행
+    auto node = rclcpp::Node::make_shared("stop_publisher");
+    auto pub = node->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 10);
+    pub->publish(message);
+
+    rclcpp::shutdown();
+}
+
+int main(int argc, char* argv[]) {
+    rclcpp::init(argc, argv);
+    auto node = make_shared<TurtlebotController>();
+
+    // move_robot() 함수를 별도의 스레드에서 실행
+    std::thread control_thread(&TurtlebotController::move_robot, node);
+
+    // Ctrl+C 시그널 핸들러 등록
+    signal(SIGINT, signalHandler);
+    rclcpp::spin(node);
+
+    // 스레드 종료 대기
+    control_thread.join();
+
+    return 0;
+}

--- a/robot_drive_pkg/src/scan.cpp
+++ b/robot_drive_pkg/src/scan.cpp
@@ -1,0 +1,106 @@
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
+#include <cmath> // std::isnan을 사용하기 위해 추가
+
+class DistanceNode : public rclcpp::Node {
+public:
+    DistanceNode() : Node("distance_node") {
+        auto qos = rclcpp::SensorDataQoS();
+        subscription_ = this->create_subscription<sensor_msgs::msg::LaserScan>(
+            "/scan", qos, std::bind(&DistanceNode::topic_callback, this, std::placeholders::_1));
+
+        publisher_aeeun_ = this->create_publisher<geometry_msgs::msg::Vector3>("aeeun", 10);
+        publisher_hyewon_ = this->create_publisher<geometry_msgs::msg::Vector3>("hyewon", 10);
+        publisher_dongwan_ = this->create_publisher<geometry_msgs::msg::Vector3>("dongwan", 10);
+    }
+
+private:
+    void topic_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg) {
+        // 원하는 각도 설정 (라디안)
+        float angle_0_rad = 0.0;
+        float angle_30_rad = M_PI / 6;  // 30도
+        float angle_60_rad = M_PI / 3;  // 60도
+        float angle_90_rad = M_PI / 2;  // 90도
+        float angle_270_rad = 3.0 * M_PI / 2;  // 270도
+        float angle_300_rad = 5.0 * M_PI / 3;  // 300도
+        float angle_330_rad = 11.0 * M_PI / 6; // 330도
+
+        // 각도에 해당하는 인덱스 계산
+        int index_0 = static_cast<int>((angle_0_rad - msg->angle_min) / msg->angle_increment);
+        int index_30 = static_cast<int>((angle_30_rad - msg->angle_min) / msg->angle_increment);
+        int index_60 = static_cast<int>((angle_60_rad - msg->angle_min) / msg->angle_increment);
+        int index_90 = static_cast<int>((angle_90_rad - msg->angle_min) / msg->angle_increment);
+        int index_270 = static_cast<int>((angle_270_rad - msg->angle_min) / msg->angle_increment);
+        int index_300 = static_cast<int>((angle_300_rad - msg->angle_min) / msg->angle_increment);
+        int index_330 = static_cast<int>((angle_330_rad - msg->angle_min) / msg->angle_increment);
+
+        // 거리 계산 (미터를 센티미터로 변환)
+        float distance_0_cm = msg->ranges[index_0] * 100.0;
+        float distance_30_cm = msg->ranges[index_30] * 100.0;
+        float distance_60_cm = msg->ranges[index_60] * 100.0;
+        float distance_90_cm = msg->ranges[index_90] * 100.0;
+        float distance_270_cm = msg->ranges[index_270] * 100.0;
+        float distance_300_cm = msg->ranges[index_300] * 100.0;
+        float distance_330_cm = msg->ranges[index_330] * 100.0;
+
+        // aeeun 토픽 메시지 생성 및 퍼블리시
+        if (!std::isnan(distance_0_cm) && distance_0_cm != 0.0 &&
+            !std::isnan(distance_90_cm) && distance_90_cm != 0.0 &&
+            !std::isnan(distance_270_cm) && distance_270_cm != 0.0) {
+
+            RCLCPP_INFO(this->get_logger(), "Distance to obstacle at 0 degrees: %.2f cm", distance_0_cm);
+            RCLCPP_INFO(this->get_logger(), "Distance to obstacle at 90 degrees: %.2f cm", distance_90_cm);
+            RCLCPP_INFO(this->get_logger(), "Distance to obstacle at 270 degrees: %.2f cm", distance_270_cm);
+
+            auto message_aeeun = geometry_msgs::msg::Vector3();
+            message_aeeun.x = distance_0_cm;
+            message_aeeun.y = distance_90_cm;
+            message_aeeun.z = distance_270_cm;
+
+            publisher_aeeun_->publish(message_aeeun);
+        }
+
+        // hyewon 토픽 메시지 생성 및 퍼블리시
+        if (!std::isnan(distance_30_cm) && distance_30_cm != 0.0 &&
+            !std::isnan(distance_60_cm) && distance_60_cm != 0.0) {
+
+            RCLCPP_INFO(this->get_logger(), "Distance to obstacle at 30 degrees: %.2f cm", distance_30_cm);
+            RCLCPP_INFO(this->get_logger(), "Distance to obstacle at 60 degrees: %.2f cm", distance_60_cm);
+
+            auto message_hyewon = geometry_msgs::msg::Vector3();
+            message_hyewon.x = distance_30_cm;
+            message_hyewon.y = distance_60_cm;
+            message_hyewon.z = 0.0;  // z 값은 사용하지 않으므로 0으로 설정
+
+            publisher_hyewon_->publish(message_hyewon);
+        }
+
+        // dongwan 토픽 메시지 생성 및 퍼블리시
+        if (!std::isnan(distance_300_cm) && distance_300_cm != 0.0 &&
+            !std::isnan(distance_330_cm) && distance_330_cm != 0.0) {
+
+            RCLCPP_INFO(this->get_logger(), "Distance to obstacle at 300 degrees: %.2f cm", distance_300_cm);
+            RCLCPP_INFO(this->get_logger(), "Distance to obstacle at 330 degrees: %.2f cm", distance_330_cm);
+
+            auto message_dongwan = geometry_msgs::msg::Vector3();
+            message_dongwan.x = distance_300_cm;
+            message_dongwan.y = distance_330_cm;
+            message_dongwan.z = 0.0;  // z 값은 사용하지 않으므로 0으로 설정
+
+            publisher_dongwan_->publish(message_dongwan);
+        }
+    }
+
+    rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr subscription_;
+    rclcpp::Publisher<geometry_msgs::msg::Vector3>::SharedPtr publisher_aeeun_;
+    rclcpp::Publisher<geometry_msgs::msg::Vector3>::SharedPtr publisher_hyewon_;
+    rclcpp::Publisher<geometry_msgs::msg::Vector3>::SharedPtr publisher_dongwan_;
+};
+
+int main(int argc, char * argv[]) {
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<DistanceNode>());
+    rclcpp::shutdown();
+    return 0;
+}


### PR DESCRIPTION
robot_drive_pkg 추가
- 센서 에서 0 혹은 nan 값은 출력과 전송 안되게 함
- 장애물 회피 로직에서 좌우 회전 방법을 따로 만듦
- right_course 함수
오른쪽으로 90도 회전->직진->왼쪽 값을 측정을 반복-> 순간적으로 값이 커지면 멈추고 반복문 종료 -> 왼쪽으로 회전한다. -> 직진한다.
- left_course 함수는 그외 반대로 이다.
- 벽 구분은 총 7개의 각도가 특정 거리 이하일 때 벽으로 인식하게 한다.
