### PR TITLE
각도와 거리를 가지고 장애물을 도트로 표시하기

### DIFF
--- a/dot_pkg/CMakeLists.txt
+++ b/dot_pkg/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.8)
+project(dot_pkg)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+add_executable(dot_node src/dot.cpp)
+ament_target_dependencies(dot_node rclcpp  sensor_msgs)
+
+install(TARGETS 
+  dot_node
+  DESTINATION lib/${PROJECT_NAME}
+    )
+
+ament_package()

--- a/dot_pkg/package.xml
+++ b/dot_pkg/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>dot_pkg</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="godma531@naver.com">hae</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/dot_pkg/src/dot.cpp
+++ b/dot_pkg/src/dot.cpp
@@ -1,0 +1,81 @@
+#include <rclcpp/rclcpp.hpp> // ROS2 C++ 클라이언트 라이브러리 헤더 파일 포함
+#include <sensor_msgs/msg/laser_scan.hpp> // Lidar 센서 데이터 메시지 타입 헤더 파일 포함
+#include <iostream> // 입출력 스트림을 사용하기 위한 헤더 파일
+#include <vector> // 벡터 컨테이너를 사용하기 위한 헤더 파일
+#include <cmath> // 수학 함수를 사용하기 위한 헤더 파일
+#include <thread> // 스레드 관련 기능을 위한 헤더 파일
+#include <chrono> // 시간 측정을 위한 헤더 파일
+
+using namespace std; // 표준 네임스페이스 사용
+
+class LidarVisualizer : public rclcpp::Node // ROS2 노드 클래스를 정의
+{
+public:
+    LidarVisualizer() : Node("lidar_visualizer") // 생성자: 노드 이름을 'lidar_visualizer'로 설정
+    {
+        // QoS 설정을 SensorDataQoS로 설정
+        auto qos = rclcpp::QoS(rclcpp::KeepLast(10)).best_effort(); // 최근 10개의 메시지를 유지하고, best_effort 전송 모드 설정
+        subscription_ = this->create_subscription<sensor_msgs::msg::LaserScan>(
+            "/scan", qos, std::bind(&LidarVisualizer::topic_callback, this, std::placeholders::_1));
+            // '/scan' 토픽을 구독하고, 메시지가 도착하면 topic_callback 함수를 호출
+    }
+
+private:
+    void topic_callback(const sensor_msgs::msg::LaserScan::SharedPtr msg) // /scan 토픽의 콜백 함수
+    {
+        const int grid_size = 150; // 2D 배열의 크기를 100x100으로 설정
+        const int center = grid_size / 2; // 2D 배열의 중심점을 계산
+        vector<vector<char>> grid(grid_size, vector<char>(grid_size, ' ')); // 빈 2D 배열 생성
+
+        // Lidar 데이터 처리
+        for (size_t i = 0; i < msg->ranges.size(); ++i) // 각 범위 데이터에 대해 반복
+        {
+            double angle = msg->angle_min + i * msg->angle_increment; // 현재 각도를 라디안 단위로 계산
+            double range = msg->ranges[i] * 100; // 거리 값을 미터에서 센티미터로 변환 (1미터 = 100센티미터)
+            
+            if (range < msg->range_min * 100 || range > msg->range_max * 100) { // 거리 값이 유효 범위 내에 있는지 확인
+                continue; // 유효하지 않으면 건너뜀
+            }
+
+            // 좌표 변환 시, Lidar 센서의 방향을 고려한 변환
+            double x = range * cos(angle); // 극좌표를 직교 좌표로 변환 (x 좌표)
+            double y = range * sin(angle); // 극좌표를 직교 좌표로 변환 (y 좌표)
+
+            // 화면 좌표계로 변환 (중심점을 기준으로)
+            int grid_x = static_cast<int>(center - y); // x 좌표를 화면 좌표계로 변환
+            int grid_y = static_cast<int>(center - x); // y 좌표를 화면 좌표계로 변환
+
+            if (grid_x >= 0 && grid_x < grid_size && grid_y >= 0 && grid_y < grid_size) // 좌표가 배열 범위 내에 있는지 확인
+            {
+                grid[grid_y][grid_x] = '*'; // 측정된 지점을 배열에 '*'로 표시
+            }
+        }
+
+        grid[center][center] = 'O'; // 그리드 중심에 터틀봇을 'O'로 표시
+
+        // 2D 배열을 터미널에 출력
+        for (const auto& row : grid) // 각 행에 대해 반복
+        {
+            for (const auto& cell : row) // 각 셀에 대해 반복
+            {
+                cout << cell; // 셀의 값을 출력
+            }
+            cout << endl; // 행이 끝나면 줄 바꿈
+        }
+        cout << endl; // 모든 행이 끝나면 추가 줄 바꿈
+
+        // 3초 동안 대기
+        std::this_thread::sleep_for(std::chrono::seconds(3)); // 3초 동안 스레드를 일시 정지
+    }
+
+    // 구독자를 위한 멤버 변수
+    rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr subscription_;
+};
+
+int main(int argc, char *argv[])
+{
+    rclcpp::init(argc, argv); // ROS2 시스템 초기화
+    rclcpp::spin(std::make_shared<LidarVisualizer>()); // LidarVisualizer 노드를 실행
+    rclcpp::shutdown(); // ROS2 시스템 종료
+    return 0; // 프로그램 종료
+}


### PR DESCRIPTION
센서가 측정할 수 있는 360도 사이의 모든 거리를 측정하고,  출력 창에서 중심에 터틀봇을 표시하고, 측정한 각 각도의 거리만큼 점을 찍어서 표현하기.

1. /scan 토픽으로 측정 가능한 각도의 값을 받아온다.

2. 2가지 배열을 만든다. 각도가 담겨있는 배열과, 각도의 거리가 담겨있는 배열.
각도에 대해서는 뒤에 올 /scan 토픽의 정보를 바탕으로 넣는다.
각도의 거리배열은 /scan 토픽의ranges 배열을 사용한다

3. grid 라는 2차원 배열을 만든다. 그리드의 크기는 100. 중심의 위치는 거리의 기준점이 된다.

4. 측정 된 거리와 각도를 바탕으로 xy,값을 구한다. 극좌표계를 직교좌표계로 변환하는 공식을 사용한다. 이때 중심점의 위치가 (0,0)이기 때문에 화면 출력 좌표로 변환한다. (중심점x + x , 중심점y - y)

5. 화면 출력 좌표로 변환한 좌표값에 맞게 grid 2차원 배열의 값을 채운다. 기준점이 되는 중심에는 "0"으로 표시한다.